### PR TITLE
Update default version to 1.0.2

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "push-artifactory"
-version: "0.4.2"
+version: "1.0.2"
 usage: "Please see https://github.com/belitre/helm-push-artifactory-plugin for usage"
 description: "Push helm charts to artifactory"
 ignoreFlags: false


### PR DESCRIPTION
Now that Helm v2 is phased out, it's time to upgrade to v3.